### PR TITLE
I've corrected an issue with the Gradle build in your CI workflow.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,4 +23,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew --project-dir ScoreboardEssential build


### PR DESCRIPTION
I found that the build was failing because the `gradlew` command was being run from the root of the repository, which doesn't contain the Gradle project files.

To fix this, I updated the GitHub Actions workflow by adding the `--project-dir` flag to the build command. This ensures that Gradle runs in the correct `ScoreboardEssential` directory.