### PR TITLE
I've downgraded Gradle and the Android Gradle Plugin to support Java …

### DIFF
--- a/ScoreboardEssential/build.gradle
+++ b/ScoreboardEssential/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.4' apply false
-    id 'com.android.library' version '8.1.4' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.10' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }

--- a/ScoreboardEssential/gradle/wrapper/gradle-wrapper.properties
+++ b/ScoreboardEssential/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 09 10:22:18 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/ScoreboardEssential/local.properties
+++ b/ScoreboardEssential/local.properties
@@ -7,3 +7,4 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
+sdk.dir=/opt/android/sdk


### PR DESCRIPTION
…11. The previous configuration required Java 17, which wasn't available in the build environment. This change downgrades the Android Gradle Plugin to version 7.4.2 and Gradle to version 7.6, which are compatible with Java 11.