### PR TITLE
Fix(wear): Resolve application ID and theme conflicts

### DIFF
--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        applicationId "com.example.scoreboardessential"
+        applicationId "com.example.scoreboardessential.wear"
         minSdk 30
         targetSdk 33
         versionCode 1

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@android:style/Theme.DeviceDefault">
+        android:theme="@style/Theme.AppCompat.NoActionBar">
         <uses-library
             android:name="com.google.android.wearable"
             android:required="true" />


### PR DESCRIPTION
The application was crashing on startup with an `IllegalStateException` requiring a `Theme.AppCompat` theme. This was caused by a configuration conflict in the `wear` module.

The `wear` module used the same `applicationId` as the `mobile` module, leading to build-time confusion. Additionally, the `wear` module depended on the AppCompat library but declared a non-AppCompat theme in its manifest.

This commit resolves the crash by:
1.  Assigning a unique `applicationId` to the `wear` module (`com.example.scoreboardessential.wear`).
2.  Updating the `wear` module's manifest to use a `Theme.AppCompat` theme, consistent with its dependencies.