### PR TITLE
Fix: Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build debug APK
       run: ./gradlew assembleDebug
     - name: Upload APK
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: app-debug.apk
         path: mobile/build/outputs/apk/debug/mobile-debug.apk


### PR DESCRIPTION
The `actions/upload-artifact@v2` action is deprecated and causes workflows to fail. This change updates the action to `v4` to resolve the issue.