### PR TITLE
Fix Android build and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,5 @@
 plugins {
     id 'com.android.application' version '8.12.0' apply false
     id 'com.android.library' version '8.12.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
 }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,17 +1,17 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
-    id 'com.google.devtools.ksp' version '1.8.0-1.0.9'
+    id 'com.google.devtools.ksp' version '2.2.0-2.0.2'
 }
 
 android {
     namespace 'com.example.scoreboardessential'
-    compileSdk 33
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.example.scoreboardessential"
         minSdk 30
-        targetSdk 33
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 
@@ -35,6 +35,10 @@ android {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.16.0'
+    implementation "androidx.activity:activity-ktx:1.10.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.2"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.9.2"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.9.2"
     implementation project(':shared')
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'

--- a/mobile/src/main/java/com/example/scoreboardessential/MatchHistoryAdapter.kt
+++ b/mobile/src/main/java/com/example/scoreboardessential/MatchHistoryAdapter.kt
@@ -10,7 +10,6 @@ import android.os.Build
 import android.os.Environment
 import android.util.DisplayMetrics
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'com.example.scoreboardessential.shared'
-    compileSdk 33
+    compileSdk 36
 
     defaultConfig {
         minSdk 30

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.example.scoreboardessential'
-    compileSdk 33
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.example.scoreboardessential.wear"
         minSdk 30
-        targetSdk 33
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 
@@ -43,4 +43,5 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.wear:wear:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.12.0'
 }

--- a/wear/src/main/res/values-night/theme.xml
+++ b/wear/src/main/res/values-night/theme.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme for Wear OS -->
-    <style name="Theme.ScoreboardEssential" parent="android:Theme.DeviceDefault.Dark">
+    <style name="Theme.ScoreboardEssential" parent="Theme.Material3.Dark.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@android:color/black</item>
         <item name="colorPrimaryDark">@android:color/black</item>


### PR DESCRIPTION
The build was failing due to several issues:
- Outdated `compileSdk` and `targetSdk` versions.
- Missing Android SDK in the build environment.
- Incompatible Kotlin plugin version with the Java 21 environment.
- Missing AndroidX dependencies after upgrading Kotlin.
- Resource linking errors in the `:wear` module.

This change addresses all these issues by:
- Updating `compileSdk` and `targetSdk` to 36.
- Adding a `local.properties` file to configure the SDK location.
- Upgrading the Kotlin plugin to 2.2.0 and the KSP plugin to 2.2.0-2.0.2.
- Adding the necessary AndroidX lifecycle dependencies to the `:mobile` module.
- Adding the Material Components dependency to the `:wear` module.
- Fixing various compilation errors that arose from the dependency upgrades.