### PR TITLE
⚡ Optimize UI performance by reusing LayoutInflater instances

### DIFF
--- a/mobile/src/main/java/it/vantaggi/scoreboardessential/PlayersManagementActivity.kt
+++ b/mobile/src/main/java/it/vantaggi/scoreboardessential/PlayersManagementActivity.kt
@@ -139,7 +139,7 @@ class PlayersManagementActivity : AppCompatActivity() {
     private fun setupRoleFilterChips(roles: List<it.vantaggi.scoreboardessential.database.Role>) {
         rolesFilterChipGroup.removeAllViews()
 
-        val inflater = android.view.LayoutInflater.from(this)
+        val inflater = layoutInflater
 
         // Add "All" chip
         val allChip =

--- a/mobile/src/main/java/it/vantaggi/scoreboardessential/utils/RoleChipExtensions.kt
+++ b/mobile/src/main/java/it/vantaggi/scoreboardessential/utils/RoleChipExtensions.kt
@@ -11,8 +11,10 @@ import it.vantaggi.scoreboardessential.database.Role
 fun ChipGroup.setRoles(roles: List<Role>) {
     removeAllViews()
 
+    val inflater = LayoutInflater.from(context)
+
     if (roles.isEmpty()) {
-        val chip = LayoutInflater.from(context).inflate(R.layout.view_role_chip, this, false) as Chip
+        val chip = inflater.inflate(R.layout.view_role_chip, this, false) as Chip
         chip.text = "N/A"
         // Use colorSurface as a default for empty state, similar to how RoleBadgeGroup did it
         val surfaceColor = MaterialColors.getColor(context, com.google.android.material.R.attr.colorSurface, 0)
@@ -22,7 +24,7 @@ fun ChipGroup.setRoles(roles: List<Role>) {
     }
 
     roles.forEach { role ->
-        val chip = LayoutInflater.from(context).inflate(R.layout.view_role_chip, this, false) as Chip
+        val chip = inflater.inflate(R.layout.view_role_chip, this, false) as Chip
         chip.text = RoleUtils.getRoleAbbreviation(role.name)
         val color = RoleUtils.getCategoryColor(context, role.category)
         chip.chipBackgroundColor = ColorStateList.valueOf(color)

--- a/mobile/src/main/java/it/vantaggi/scoreboardessential/views/FormationView.kt
+++ b/mobile/src/main/java/it/vantaggi/scoreboardessential/views/FormationView.kt
@@ -69,15 +69,18 @@ class FormationView
             val midY = 0.50f
             val fwdY = 0.25f
 
-            addPlayersRow(currentFormation.goalkeeper, gkY)
-            addPlayersRow(currentFormation.defenders, defY)
-            addPlayersRow(currentFormation.midfielders, midY)
-            addPlayersRow(currentFormation.forwards, fwdY)
+            val inflater = LayoutInflater.from(context)
+
+            addPlayersRow(currentFormation.goalkeeper, gkY, inflater)
+            addPlayersRow(currentFormation.defenders, defY, inflater)
+            addPlayersRow(currentFormation.midfielders, midY, inflater)
+            addPlayersRow(currentFormation.forwards, fwdY, inflater)
         }
 
         private fun addPlayersRow(
             players: List<PlayerWithRoles>,
             yPercent: Float,
+            inflater: LayoutInflater,
         ) {
             if (players.isEmpty()) return
 
@@ -86,7 +89,7 @@ class FormationView
             val spacing = width.toFloat() / (count + 1)
 
             players.forEachIndexed { index, player ->
-                val playerView = LayoutInflater.from(context).inflate(R.layout.view_formation_player_marker, this, false)
+                val playerView = inflater.inflate(R.layout.view_formation_player_marker, this, false)
 
                 // Setup dati giocatore
                 val cardView = playerView.findViewById<MaterialCardView>(R.id.card_avatar)


### PR DESCRIPTION
💡 **What:** Optimized UI rendering performance by ensuring `LayoutInflater` instances are retrieved once and reused when inflating multiple views in a loop.

🎯 **Why:** Retrieving a `LayoutInflater` (via `LayoutInflater.from(context)`) involves a system service lookup. Performing this lookup repeatedly inside a loop (e.g., when inflating chips or player markers) is a known performance anti-pattern in Android that can cause UI jank.

📊 **Measured Improvement:** While environmental constraints prevented running a high-iteration benchmark test in the sandbox, the theoretical benefit of avoiding redundant system service lookups and adhering to Android performance best practices is well-documented. Hoisting the inflater retrieval in `RoleChipExtensions` and `FormationView` directly reduces the CPU overhead during complex UI rendering tasks.

---
*PR created automatically by Jules for task [6164494409532370341](https://jules.google.com/task/6164494409532370341) started by @vantaggi*