### PR TITLE
🧹 Remove unused private functions in PlayersManagementActivity

### DIFF
--- a/mobile/src/main/java/it/vantaggi/scoreboardessential/PlayersManagementActivity.kt
+++ b/mobile/src/main/java/it/vantaggi/scoreboardessential/PlayersManagementActivity.kt
@@ -225,17 +225,6 @@ class PlayersManagementActivity : AppCompatActivity() {
             .show()
     }
 
-    private fun showDeleteConfirmation(playerWithRoles: PlayerWithRoles) {
-        MaterialAlertDialogBuilder(this)
-            .setTitle("Delete Player?")
-            .setMessage("Are you sure you want to delete ${playerWithRoles.player.playerName}? This action cannot be undone.")
-            .setPositiveButton("Delete") { _, _ ->
-                viewModel.deletePlayer(playerWithRoles)
-                Snackbar.make(fab, "Player deleted", Snackbar.LENGTH_SHORT).show()
-            }.setNegativeButton("Cancel", null)
-            .show()
-    }
-
     private fun showResetStatsConfirmation(playerWithRoles: PlayerWithRoles) {
         MaterialAlertDialogBuilder(this)
             .setTitle("Reset Statistics?")
@@ -246,16 +235,6 @@ class PlayersManagementActivity : AppCompatActivity() {
                 Snackbar.make(fab, "Stats reset", Snackbar.LENGTH_SHORT).show()
             }.setNegativeButton("Cancel", null)
             .show()
-    }
-
-    private fun showEmptyState() {
-        findViewById<androidx.constraintlayout.widget.ConstraintLayout>(R.id.empty_state)
-            ?.visibility = android.view.View.VISIBLE
-    }
-
-    private fun hideEmptyState() {
-        findViewById<androidx.constraintlayout.widget.ConstraintLayout>(R.id.empty_state)
-            ?.visibility = android.view.View.GONE
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
The code health improvement task involved identifying and removing unused private functions in `PlayersManagementActivity.kt`.

### 🎯 What:
Removed the following unused private functions:
- `showEmptyState()`
- `hideEmptyState()`
- `showDeleteConfirmation()`

### 💡 Why:
Removing dead code improves maintainability and readability by reducing clutter and potential confusion for future developers. These functions were confirmed to be unreferenced within their scope.

### ✅ Verification:
- Manual inspection of `PlayersManagementActivity.kt` confirmed no call sites for these functions.
- `grep` searches verified the absence of references within the file.
- Code review from a peer confirmed the correctness and safety of the changes.

### ✨ Result:
A cleaner and more maintainable `PlayersManagementActivity.kt` with all identifiable dead code removed.

---
*PR created automatically by Jules for task [6552281982030072914](https://jules.google.com/task/6552281982030072914) started by @vantaggi*