### PR TITLE
🔒 [security fix] Harden PendingIntent usage in MatchTimerService

### DIFF
--- a/mobile/src/main/java/it/vantaggi/scoreboardessential/service/MatchTimerService.kt
+++ b/mobile/src/main/java/it/vantaggi/scoreboardessential/service/MatchTimerService.kt
@@ -378,18 +378,31 @@ class MatchTimerService : Service() {
 
     // --- Foreground Service & Notifications ---
     private val pendingIntent by lazy {
-        val notificationIntent = Intent(this, MainActivity::class.java)
-        PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
+        val notificationIntent = Intent(this, MainActivity::class.java).apply { setPackage(packageName) }
+        PendingIntent.getActivity(
+            this,
+            0,
+            notificationIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
     }
 
     private val pausePendingIntent by lazy {
-        val pauseIntent = Intent(this, MatchTimerService::class.java).apply { action = ACTION_PAUSE }
-        PendingIntent.getService(this, 0, pauseIntent, PendingIntent.FLAG_IMMUTABLE)
+        val pauseIntent =
+            Intent(this, MatchTimerService::class.java).apply {
+                action = ACTION_PAUSE
+                setPackage(packageName)
+            }
+        PendingIntent.getService(this, 0, pauseIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
     }
 
     private val stopPendingIntent by lazy {
-        val stopIntent = Intent(this, MatchTimerService::class.java).apply { action = ACTION_STOP }
-        PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE)
+        val stopIntent =
+            Intent(this, MatchTimerService::class.java).apply {
+                action = ACTION_STOP
+                setPackage(packageName)
+            }
+        PendingIntent.getService(this, 0, stopIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
     }
 
     private fun createNotification(timeInMillis: Long): Notification {
@@ -425,11 +438,27 @@ class MatchTimerService : Service() {
         ) {
             return
         }
-        val notificationIntent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
+        val notificationIntent = Intent(this, MainActivity::class.java).apply { setPackage(packageName) }
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                notificationIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
 
-        val dismissalIntent = Intent(this, MatchTimerService::class.java).apply { action = ACTION_DISMISS_ALARM }
-        val dismissalPendingIntent = PendingIntent.getService(this, 0, dismissalIntent, PendingIntent.FLAG_IMMUTABLE)
+        val dismissalIntent =
+            Intent(this, MatchTimerService::class.java).apply {
+                action = ACTION_DISMISS_ALARM
+                setPackage(packageName)
+            }
+        val dismissalPendingIntent =
+            PendingIntent.getService(
+                this,
+                0,
+                dismissalIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
 
         val notification =
             NotificationCompat


### PR DESCRIPTION
🎯 **What:** Hardened the security of `PendingIntent` creation in `MatchTimerService.kt` by explicitly setting the intent package and updating flags.
⚠️ **Risk:** Although `FLAG_IMMUTABLE` was already present, missing `setPackage()` on intents could potentially allow intent redirection or interception by malicious apps on older Android versions or in specific configurations.
🛡️ **Solution:**
- Added `setPackage(packageName)` to all explicit intents used in `PendingIntent`s within `MatchTimerService`. This ensures that the intents can only be delivered to this specific application, providing defense-in-depth.
- Combined `FLAG_IMMUTABLE` with `FLAG_UPDATE_CURRENT` for all `PendingIntent`s to ensure they are correctly updated by the system when recreated, following Android development best practices.

---
*PR created automatically by Jules for task [2780891159094915957](https://jules.google.com/task/2780891159094915957) started by @vantaggi*